### PR TITLE
Small fix for rename/delete edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Active note to window title
 
-Fork of [jplattel/open-note-to-window-title](https://github.com/jplattel/open-note-to-window-title) for the purpose of submitting a PR. Do not use.
+This might be the smallest Obsidian plugin, but it adds the current open note to the window title, like so:
+
+`obsidian - Obsidian v0.11.0 - testing/currently-open-note-for-project-xyz.md`
+
+This is useful when you are tracking your application usage with [Timing](https://timingapp.com/?lang=en) (or any other app that uses window title). Otherwise it might prove useful for context what you're doing when switching with alt-tab if your application switcher allows for filtering like [contexts.app](https://contexts.co/).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
 # Active note to window title
 
-This might be the smallest Obsidian plugin, but it adds the current open note to the window title, like so:
-
-`obsidian - Obsidian v0.11.0 - testing/currently-open-note-for-project-xyz.md`
-
-This is useful when you are tracking your application usage with [Timing](https://timingapp.com/?lang=en) (or any other app that uses window title). Otherwise it might prove useful for context what you're doing when switching with alt-tab if your application switcher allows for filtering like [contexts.app](https://contexts.co/).
+Fork of [jplattel/open-note-to-window-title](https://github.com/jplattel/open-note-to-window-title) for the purpose of submitting a PR. Do not use.

--- a/main.ts
+++ b/main.ts
@@ -18,11 +18,15 @@ export default class ActiveNoteTitlePlugin extends Plugin {
 	}
 
 	private readonly handleRename = async (file: TFile): Promise<void> => {
-		document.title = this.baseTitle + ' - ' + file.path;
+		if (file instanceof TFile && file === this.app.workspace.getActiveFile()) {
+			document.title = this.baseTitle + ' - ' + file.path;
+		}
 	};
 
 	private readonly handleDelete = async (file: TFile): Promise<void> => {
-		document.title = this.baseTitle;
+		if (this.app.workspace.getActiveFile() === null || this.app.workspace.getActiveFile() === undefined) {
+			document.title = this.baseTitle;
+		}
 	};
 
 	private readonly handleOpen = async (file: TFile): Promise<void> => {


### PR DESCRIPTION
Hey @jplattel 👋 

This small PR fixes 2 edge cases:

1. non-active file renamed from the side panel incorrectly sets the title of the active document
2. deleting non-active file causes title to revert to default even if there is still an open note

(thanks to @pjeby for inspiration from https://github.com/ravimashru/obsidian-show-file-path/pull/3/commits/59c49b771db7d9ac91091ccc78f5ef6ce726db87)